### PR TITLE
input_default.cpp

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -912,6 +912,7 @@ void InputDefault::joy_axis(int p_device, int p_axis, const JoyAxis &p_value) {
 
 	if (joy.mapping == -1) {
 		_axis_event(p_device, p_axis, val);
+		return;
 	};
 
 	Map<int, JoyEvent>::Element *el = map_db[joy.mapping].axis.find(p_axis);


### PR DESCRIPTION
If the mapping is -1, as it will be in the fallback case, it still continues and checks map_db[joy.mapping]
which is quite invalid, and then it goes on to get a property of that, which means if map_db[-1] doesn't cause issues and instead gives, say, NULL, it will still fail. I think.
There's a similar "== -1" check in joy_button, but that code has a return; after it.
So I'm guessing the return; was omitted.

added return; in line 915